### PR TITLE
Haxe code  splitting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 yarn-error.log
+node_modules/

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ module.exports = {
 You can also add some convenience scripts to your `package.json`:
 
     "scripts": {
-        "webpack": "node node_modules/webpack/bin/webpack.js",
-        "watch": "node node_modules/webpack/bin/webpack.js --watch"
+        "webpack": "webpack",
+        "watch": "webpack --watch"
     },
 
 Now you can run:
@@ -59,23 +59,40 @@ Please note `npm run ...` also works just fine.
 
 ### Requiring files
 
-To require files, you can use [`js.Lib.require()`](http://api.haxe.org/js/Lib.html#require) or, on externs you can add `@:jsRequire` metadata.
+Note: you must add `-lib haxe-loader` to your HXML to use the `Webpack` class.
 
-These both generate `require()` statements that webpack will process when it compiles.
+#### Synchronous requires
 
-One problem with `js.Lib.require()` is that it imports relative to the HXML file, rather than relative to the current HX file.  It also cannot be compiled on platforms other than JS.
+To require 3rd party NPM modules, you can use `@:jsRequire` metadata or
+[`js.Lib.require()`](http://api.haxe.org/js/Lib.html#require).
 
-We have a convenience method you can call instead:
+However, those requires are relative to you HXML file! 
+It also cannot be compiled on platforms other than JS.
 
-    Webpack.require('./MyFile.css');
+It is thus recommended to call instead:
 
-This will generate a `js.Lib.require()` call, and the `./` makes it relative to the current `*.hx` file. It will call `js.Lib.require()` on Javascript targets, and be silently ignored on all other targets.  In future we may try to handle require statements for other targets.
+```haxe
+Webpack.require('./MyFile.css');    // requires a CSS loader
+Webpack.require('../locales.json'); // requires to enable JS loader for JSON
+```
 
-Please note when you compile through webpack, the `Webpack` class is made available.
-If you try to compile the hxml file directly though, or use the hxml file for completion, it may not know where to find the `Webpack.hx` file.
-You can add the class path to your hxml file:
+It is silently ignored on non-JS targets. 
+In future we may try to handle require statements for other targets.
 
-    -cp node_modules/haxe-loader/haxelib
+#### Asynchronous requires (code splitting)
+
+To leverage code splitting, you must use the `Webpack.async` require, 
+and provide the Haxe module you want to load as a separate bundle:
+
+```haxe
+import com.MyComponent;
+...
+Webpack.async(MyComponent).then(function(_){
+    var comp = new myComponent();
+});
+```
+
+Using this API, the Haxe compiler output will be processed and cut into separate files.
 
 ### Dev server setup
 

--- a/haxelib/Webpack.hx
+++ b/haxelib/Webpack.hx
@@ -5,12 +5,11 @@ using tink.MacroApi;
 using haxe.io.Path;
 #end
 
-extern class Webpack {
+class Webpack {
 	/**
 	 * JavaScript 'require' function, for synchronous module loading
 	 */
-	public static macro function require(fileExpr:ExprOf<String>):ExprOf<Any> {
-		#if macro
+	public static macro function require(fileExpr:ExprOf<String>) {
 		if (Context.defined('js')) {
 			// If the file path begins with "./"
 			var file = fileExpr.getString().sure();
@@ -25,7 +24,6 @@ extern class Webpack {
 			// Perhaps by tracking in metadata and saving to the JSON outputFile, and processng inside the loader.
 			return macro (null:Any);
 		}
-		#end
 	}
 
 	/**

--- a/haxelib/Webpack.hx
+++ b/haxelib/Webpack.hx
@@ -29,7 +29,7 @@ class Webpack {
 	/**
 	 * JavaScript 'import' function, for asynchronous module loading
 	 */
-	public static macro function load(classRef:Expr) {
+	public static macro function bundle(classRef:Expr) {
 		switch (Context.typeof(classRef)) {
 			case haxe.macro.Type.TType(_.get() => t, _):
 				var module = t.module.split('.').join('_');

--- a/haxelib/haxelib.json
+++ b/haxelib/haxelib.json
@@ -1,0 +1,13 @@
+{
+  "name": "haxe-loader",
+  "url": "https://github.com/jasononeil/webpack-haxe-loader",
+  "license": "MIT",
+  "tags": ["webpack", "js"],
+  "description": "Haxe loader for webpack",
+  "version": "0.0.1",
+  "releasenote": "",
+  "contributors": ["jason", "elsassph"],
+  "dependencies": {
+    "tink_macro": "0.14.0"
+  }
+}

--- a/haxelib/haxelib.json
+++ b/haxelib/haxelib.json
@@ -6,8 +6,5 @@
   "description": "Haxe loader for webpack",
   "version": "0.0.1",
   "releasenote": "",
-  "contributors": ["jason", "elsassph"],
-  "dependencies": {
-    "tink_macro": "0.14.0"
-  }
+  "contributors": ["jason", "elsassph"]
 }

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 "use_strict";
 
+const loaderUtils = require('loader-utils');
 const fs = require('fs');
 const path = require('path');
 const exec = require('child_process').exec;
@@ -29,6 +30,7 @@ module.exports = function(hxmlContent) {
     registerDepencencies(context, classpath);
 
     // Execute the Haxe build.
+    console.log('haxe', args.join(' '));
     exec(`haxe ${args.join(' ')}`, (err, stdout, stderr) => {
         if (err) {
             return cb(err);
@@ -154,6 +156,7 @@ function registerDepencencies(context, classpath) {
 }
 
 function prepare(context, ns, hxmlContent, jsTempFile) {
+    const options = loaderUtils.getOptions(context) || {};
     const args = [];
     const classpath = [];
     let jsOutputFile = null;
@@ -195,5 +198,8 @@ function prepare(context, ns, hxmlContent, jsTempFile) {
             args.push(value);
         }
     }
+
+    if (options.extra) args.push(options.extra);
+
     return { jsOutputFile, classpath, args };
 }

--- a/index.js
+++ b/index.js
@@ -1,18 +1,162 @@
+"use_strict";
+
 const fs = require('fs');
 const path = require('path');
 const exec = require('child_process').exec;
+const loaderUtils = require('loader-utils');
+const tmp = require('tmp');
+const hash = require('hash-sum');
+const split = require('./node_modules/haxe-modular/tool/bin/split');
+
+const cache = Object.create(null);
 
 module.exports = function(hxmlContent) {
-    if (this.cacheable) {
-        this.cacheable();
-    }
+
+    console.log('LOCAL VERSION');
+
+    this.cacheable && this.cacheable();
     const cb = this.async();
 
+    const request = this.resourcePath;
+    if (!request) {
+        // Loader was called without specifying a hxml file
+        // Expecting a require of the form '!haxe-loader?hxmlName/moduleName!'
+        fromCache(this, this.query, cb);
+        return;
+    }
+
+    const ns = path.basename(request).replace('.hxml', '');
+    const options = loaderUtils.getOptions(this) || {};
+    const jsTempFile = makeJSTempFile(ns);
+    const { jsOutputFile, classpath, args } = prepare(this, hxmlContent, jsTempFile);
+    args.push('-D', `webpack_namespace=${ns}`);
+
+    // Execute the Haxe build.
+    exec(`haxe ${args.join(' ')}`, (err, stdout, stderr) => {
+        if (err) {
+            return cb(err);
+        }
+
+        if (!jsOutputFile) {
+            // If the hxml file outputs something other than JS, we should not include it in the bundle.
+            // We're only passing it through webpack so that we get `watch` and the like to work.
+            return cb(null, "");
+        }
+
+        // Read the resulting JS file and return the main module
+        const processed = processOutput(ns, jsTempFile, jsOutputFile);
+        if (processed) {
+            updateCache(this, ns, processed, classpath);
+        }
+        returnModule(this, ns, 'Main', cb);
+    });
+};
+
+function updateCache(context, ns, { contentHash, results }, classpath) {
+    cache[ns] = { contentHash, results, classpath };
+}
+
+function processOutput(ns, jsTempFile, jsOutputFile) {
+    const content = fs.readFileSync(jsTempFile.path);
+    // Check whether the output has changed since last build
+    const contentHash = hash(content);
+    if (cache[ns] && cache[ns].hash === contentHash) 
+        return null;
+
+    // Split output
+    const modules = findImports(content);
+    const results = split.run(jsTempFile.path, jsOutputFile, modules, this.debug, true)
+        .filter(entry => entry && entry.source);
+    
+    // Inject .hx sources in map file
+    results.forEach(entry => {
+        if (entry.map) {
+            const map = entry.map.content = JSON.parse(entry.map.content);
+            map.sourcesContent = map.sources.map(path => {
+                try {
+                    if (path.startsWith('file:///')) path = path.substr(8);
+                    return fs.readFileSync(path).toString();
+                } catch (_) {
+                    return '';
+                }
+            });
+        }
+    });
+
+    // Delete temp files
+    jsTempFile.cleanup();
+    
+    return { contentHash, results };
+}
+
+function returnModule(context, ns, name, cb) {
+    const { results, classpath } = cache[ns];
+    if (!results.length) {
+        throw new Error(`${ns}.hxml did not emit any modules`);
+    }
+
+    const entry = results.find(entry => entry.name === name);
+    if (!entry) {
+        throw new Error(`${ns}.hxml did not emit a module called '${name}'`);
+    }
+
+    // TODO we need smarter dependency flagging
+    classpath.forEach(path => context.addContextDependency(path));
+    cb(null, entry.source.content, entry.map ? entry.map.content : null);
+}
+
+function fromCache(context, query, cb) {
+    // To locate a split module we expect a query of the form '?hxmlName/moduleName'
+    const options = /\?([^/]+)\/(.*)/.exec(query);
+    if (!options) {
+        throw new Error(`Invalid query: ${query}`);
+    }
+    const ns = options[1];
+    const name = options[2];
+
+    const cached = cache[ns];
+    if (!cached) {
+        throw new Error(`${ns}.hxml is not a known entry point`);
+    }
+    if (!cached.results.length) {
+        throw new Error(`${ns}.hxml did not emit any modules`);
+    }
+    returnModule(context, ns, name, cb);
+}
+
+function findImports(content) {
+    // Webpack.load() emits a call to System.import with a query to haxe-loader
+    const reImports = /System.import\("!haxe-loader\?([^!]+)/g;
+    const results = [];
+
+    let match = reImports.exec(content);
+    while (match) {
+        // Module reference  is of the form 'hxmlName/moduleName'
+        const name = match[1].substr(match[1].indexOf('/') + 1);
+        results.push(name);
+        match = reImports.exec(content);
+    }
+    return results;
+}
+
+function makeJSTempFile() {
+    const path = tmp.tmpNameSync({ postfix: '.js' });
+    const cleanup = () => {
+        try {
+            fs.unlink(path);
+            fs.unlink(`${path}.map`);
+        } catch (_) {}
+    };
+    return { path, cleanup };
+}
+
+function prepare(context, hxmlContent, jsTempFile) {
+    const args = [];
+    const classpath = [];
     let jsOutputFile = null;
-    let args = [];
 
     // Add args that are specific to hxml-loader
-    if (this.debug) {
+    if (context.debug) {
         args.push('-debug');
     }
     // We use a special macro to output a file containing all `*.hx` source files used in the haxe build.
@@ -28,52 +172,28 @@ module.exports = function(hxmlContent) {
         }
 
         let space = line.indexOf(' ');
-
         let name = space > -1 ? line.substr(0, space) : line;
         args.push(name);
 
         if (name === '--next') {
-            var err = `${this
-                .resourcePath} included a "--next" line, hxml-loader only supports a single build per hxml file.`;
-            return cb(err);
+            var err = `${context.resourcePath} included a "--next" line, hxml-loader only supports a single build per hxml file.`;
+            throw new Error(err);
         }
 
         if (space > -1) {
             let value = line.substr(space + 1).trim();
-            args.push(value);
 
             if (name === '-js') {
                 jsOutputFile = value;
-            } else if (name === '-cp') {
-                var classPath = path.resolve(value);
-                this.addContextDependency(classPath);
+                args.push(jsTempFile.path);
+                continue;
             }
+            
+            if (name === '-cp') {
+                classpath.push(path.resolve(value));
+            }
+            args.push(value);
         }
     }
-
-    // Execute the Haxe build.
-    exec(`haxe ${args.join(' ')}`, (err, stdout, stderr) => {
-        if (stdout) {
-            console.log(stdout);
-        }
-        if (stderr) {
-            console.error(stderr);
-        }
-        if (err) {
-            return cb(err);
-        }
-
-        if (!jsOutputFile) {
-            // If the hxml file outputs something other than JS, we should not include it in the bundle.
-            // We're only passing it through webpack so that we get `watch` and the like to work.
-            return cb(null, "");
-        }
-
-        // Read the resulting JS file.
-        fs.readFile(jsOutputFile, (err, data) => {
-            if (err) return cb(err);
-
-            return cb(null, data);
-        });
-    });
-};
+    return { jsOutputFile, classpath, args };
+}

--- a/package.json
+++ b/package.json
@@ -7,5 +7,10 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/jasononeil/webpack-haxe-loader.git"
+  },
+  "dependencies": {
+    "hash-sum": "^1.0.2",
+    "haxe-modular": "git://github.com/elsassph/haxe-modular.git#feature/webpack",
+    "tmp": "0.0.31"
   }
 }


### PR DESCRIPTION
This PR introduces Haxe code splitting based on `haxe-modular`.

I suggest  to make a haxelib of `haxe-loader` - though not strictly necessary (the `-cp` did the job) it allows IDEs to resolve the Webpack helper class (and possibly more helpers in the future).

Note: I didn't try the 'non-JS' hxml use case.