### PR TITLE
Modular refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Note: you must add `-lib haxe-loader` to your HXML to use the `Webpack` class.
 To require 3rd party NPM modules, you can use `@:jsRequire` metadata or
 [`js.Lib.require()`](http://api.haxe.org/js/Lib.html#require).
 
-However, those requires are relative to you HXML file! 
+However, those requires are relative to you HXML file!
 It also cannot be compiled on platforms other than JS.
 
 It is thus recommended to call instead:
@@ -76,12 +76,12 @@ Webpack.require('./MyFile.css');    // requires a CSS loader
 Webpack.require('../locales.json'); // requires to enable JS loader for JSON
 ```
 
-It is silently ignored on non-JS targets. 
+It is silently ignored on non-JS targets.
 In future we may try to handle require statements for other targets.
 
 #### Asynchronous requires (code splitting)
 
-To leverage code splitting, you must use the `Webpack.async` require, 
+To leverage code splitting, you must use the `Webpack.async` require,
 and provide the Haxe module you want to load as a separate bundle:
 
 ```haxe
@@ -132,6 +132,33 @@ If you have a backend you want to use, for example Nekotools running on `http://
         publicPath: "/js/"
     },
 
-### Copyright and License
+### Contributing
 
-Created by Jason O'Neil in 2017.  Released under the MIT license.
+Don't hesitate to create a pull request. Every contribution is appreciated.
+
+## Maintainers
+
+<table>
+  <tbody>
+    <tr>
+      <td align="center">
+        <a href="https://github.com/jasononeil">
+          <img width="150" height="150" src="https://github.com/jasononeil.png?v=3&s=150">
+          </br>
+          Jason O'Neil
+        </a>
+      </td>
+      <td align="center">
+        <a href="https://github.com/elsassph">
+          <img width="150" height="150" src="https://github.com/elsassph.png?v=3&s=150">
+          </br>
+          Philippe Elsass
+        </a>
+      </td>
+    </tr>
+  <tbody>
+</table>
+
+### License
+
+MIT

--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ function processOutput(ns, jsTempFile, jsOutputFile, mainClass) {
     const content = fs.readFileSync(jsTempFile.path);
     // Check whether the output has changed since last build
     const contentHash = hash(content);
-    if (cache[ns] && cache[ns].hash === contentHash) 
+    if (cache[ns] && cache[ns].hash === contentHash)
         return null;
 
     // Split output
@@ -67,7 +67,7 @@ function processOutput(ns, jsTempFile, jsOutputFile, mainClass) {
     const debug = fs.existsSync(`${jsTempFile.path}.map`);
     const results = split.run(jsTempFile.path, jsOutputFile, modules, debug, true)
         .filter(entry => entry && entry.source);
-    
+
     // Inject .hx sources in map file
     results.forEach(entry => {
         if (entry.map) {
@@ -85,7 +85,7 @@ function processOutput(ns, jsTempFile, jsOutputFile, mainClass) {
 
     // Delete temp files
     jsTempFile.cleanup();
-    
+
     return { contentHash, results };
 }
 
@@ -169,6 +169,7 @@ function prepare(context, ns, hxmlContent, jsTempFile) {
     args.push('-D', `webpack_namespace=${ns}`);
 
     // Process all of the args in the hxml file.
+    var flattenClassNames = true;
     for (let line of hxmlContent.split('\n')) {
         line = line.trim();
         if (line === '' || line.substr(0, 1) === '#') {
@@ -195,12 +196,21 @@ function prepare(context, ns, hxmlContent, jsTempFile) {
                 args.push(jsTempFile.path);
                 continue;
             }
-            
+
             if (name === '-cp') {
                 classpath.push(path.resolve(value));
             }
+
+            if (name === '-D' && value === 'js-unflatten') {
+                flattenClassNames = false;
+            }
+
             args.push(value);
         }
+    }
+
+    if (flattenClassNames) {
+        mainClass = mainClass.replace('.', '_');
     }
 
     if (options.extra) args.push(options.extra);

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ module.exports = function(hxmlContent) {
 
     const ns = path.basename(request).replace('.hxml', '');
     const jsTempFile = makeJSTempFile(ns);
-    const { jsOutputFile, classpath, args } = prepare(context, ns, hxmlContent, jsTempFile);
+    const { jsOutputFile, classpath, args, mainClass } = prepare(context, ns, hxmlContent, jsTempFile);
 
     registerDepencencies(context, classpath);
 
@@ -43,7 +43,7 @@ module.exports = function(hxmlContent) {
         }
 
         // Read the resulting JS file and return the main module
-        const processed = processOutput(ns, jsTempFile, jsOutputFile);
+        const processed = processOutput(ns, jsTempFile, jsOutputFile, mainClass);
         if (processed) {
             updateCache(context, ns, processed, classpath);
         }
@@ -55,7 +55,7 @@ function updateCache(context, ns, { contentHash, results }, classpath) {
     cache[ns] = { contentHash, results, classpath };
 }
 
-function processOutput(ns, jsTempFile, jsOutputFile) {
+function processOutput(ns, jsTempFile, jsOutputFile, mainClass) {
     const content = fs.readFileSync(jsTempFile.path);
     // Check whether the output has changed since last build
     const contentHash = hash(content);
@@ -63,7 +63,7 @@ function processOutput(ns, jsTempFile, jsOutputFile) {
         return null;
 
     // Split output
-    const modules = findImports(content);
+    const modules = [mainClass].concat(findImports(content));
     const debug = fs.existsSync(`${jsTempFile.path}.map`);
     const results = split.run(jsTempFile.path, jsOutputFile, modules, debug, true)
         .filter(entry => entry && entry.source);
@@ -160,9 +160,10 @@ function prepare(context, ns, hxmlContent, jsTempFile) {
     const args = [];
     const classpath = [];
     let jsOutputFile = null;
+    let mainClass = 'Main';
 
     // Add args that are specific to hxml-loader
-    if (context.sourceMap) {
+    if (options.debug) {
         args.push('-debug');
     }
     args.push('-D', `webpack_namespace=${ns}`);
@@ -181,6 +182,9 @@ function prepare(context, ns, hxmlContent, jsTempFile) {
         if (name === '--next') {
             var err = `${context.resourcePath} included a "--next" line, hxml-loader only supports a single build per hxml file.`;
             throw new Error(err);
+        }
+        if (name == '-main') {
+            mainClass = line.substr(space + 1);
         }
 
         if (space > -1) {
@@ -201,5 +205,5 @@ function prepare(context, ns, hxmlContent, jsTempFile) {
 
     if (options.extra) args.push(options.extra);
 
-    return { jsOutputFile, classpath, args };
+    return { jsOutputFile, classpath, args, mainClass };
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "hash-sum": "^1.0.2",
-    "haxe-modular": "git://github.com/elsassph/haxe-modular.git#feature/webpack",
+    "haxe-modular": "git://github.com/elsassph/haxe-modular.git#feature/webpack_refactoring",
     "tmp": "0.0.31",
     "loader-utils": "^1.1.0"
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "haxe-loader",
   "description": "Make loader-utils a real dependency",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "author": "Jason O'Neil <jason.oneil@gmail.com>",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Haxe modular has been refactored and now requires the main class as 1st module.

Additional change: Haxe loader now needs `debug:true` as loader option to generate Haxe with `-debug`.