### PR TITLE
React HMR support

### DIFF
--- a/haxelib/ReactHMR.hx
+++ b/haxelib/ReactHMR.hx
@@ -1,0 +1,39 @@
+class ReactHMR
+{
+	/**
+	 * Deep refresh the provided React component when a module is reloaded.
+     * This function should be only called once.
+     *
+     * Usage:
+     * 
+     *     var rootComponent = ReactDOM.render(...);
+     *     #if debug 
+     *     ReactHMR.autoRefresh(rootComponent);
+     *     #end
+	 */
+	static public function autoRefresh(component:Dynamic) 
+	{
+        if (untyped module.hot) {
+            var dirty = false;
+            untyped module.hot.status(function(status) {
+                if (status == 'apply') dirty = true;
+                else if (status == 'idle' && dirty) {
+                    dirty = false;
+                    if (component._reactInternalInstance) {
+                        HMRClient.refresh(component);
+                    }
+                }
+            });
+        }
+	}
+}
+
+/**
+ * React HMR client code:
+ * - registers and proxies React component classes,
+ * - when `refresh` is called, runs a deep force-update of the given component.
+ */
+@:jsRequire('haxe-modular')
+extern class HMRClient {
+    static public function refresh(component:Dynamic):Void;
+}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "dependencies": {
     "hash-sum": "^1.0.2",
-    "haxe-modular": "^0.3.0",
+    "haxe-modular": "^0.4.0",
     "loader-utils": "^1.1.0",
     "tmp": "0.0.31"
   }


### PR DESCRIPTION
Haxe-modular has been updated with: 

- fixes to code generation,
- fix to haxe-modular client,

allowing React Hot Module Replacement to function with Webpack Haxe Loader.

Note: this requires both npm and haxelib releases