### PR TITLE
Block haxe-modular lib, as it's output is incompatible with haxe-loader

### DIFF
--- a/index.js
+++ b/index.js
@@ -225,6 +225,10 @@ function prepare(options, context, ns, hxmlContent, jsTempFile) {
                 }
             }
 
+            if (name === '-lib' && value.startsWith('modular')) {
+                throw new Error('When using haxe-loader, you need to remove `-lib modular` from your hxml file');
+            }
+
             args.push(value);
         }
     }


### PR DESCRIPTION
Fixes #26