### PR TITLE
Macro with single quotes need to be quoted

### DIFF
--- a/index.js
+++ b/index.js
@@ -225,6 +225,12 @@ function prepare(options, context, ns, hxmlContent, jsTempFile) {
                 }
             }
 
+            if (name == '--macro') {
+                // quote macro value
+                args.push(`"${value}"`);
+                continue;
+            }
+
             args.push(value);
         }
     }


### PR DESCRIPTION
Fixes #28, but may not be as generic as desirable. 

Proper fix would require to generate a temporary hxml file with JS output substitued.