### PR TITLE
Couple of internal improvements

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,6 +2,11 @@
 
 ## Next
 
+## 0.9.0
+
+* ✨ Add `Webpack.createLoader()` in macro context, allowing custom macros to create code splitting points.
+* ✅ Originally main module updates were ignored, now the page is reloaded. (It is still possible to accept updates to the main entrypoint and handle them gracefully if you set it up).
+
 ## 0.8.0
 
 * ✨: Add `sizeReport` option to generate JSON and HTML size reports.

--- a/haxelib/ReactHMR.hx
+++ b/haxelib/ReactHMR.hx
@@ -12,27 +12,23 @@ class ReactHMR {
 	 *
 	 * Usage:
 	 *
-	 *     var rootComponent = ReactDOM.render(...);
-	 *     #if debug
-	 *     ReactHMR.autoRefresh(rootComponent);
-	 *     #end
+	 *	 var rootComponent = ReactDOM.render(...);
+	 *	 #if debug
+	 *	 ReactHMR.autoRefresh(rootComponent);
+	 *	 #end
 	 */
 	static public function autoRefresh(component:Dynamic, autoReloadMain:Bool = true) {
 		var hot:ModuleHMR = untyped module.hot;
-
 		if (hot != null) {
-			// if main module has changed, reload the page
+			// allow main module to be updated
+			hot.accept();
 			if (autoReloadMain) {
-				if (hot.data != null && hot.data.forceReload) {
-					js.Browser.document.location.reload();
-					return;
-				}
+				// BUT if main module has changed, reload the page
 				hot.dispose(function (data) {
-					data.forceReload = true;
+					js.Browser.document.location.reload();
 				});
 			}
-			hot.accept();
-			// if a sub-module has changed, force deep React re-render
+			// if a module has changed, force deep React re-render
 			var dirty = false;
 			hot.status(function(status) {
 				if (status == 'apply') dirty = true;

--- a/haxelib/ReactHMR.hx
+++ b/haxelib/ReactHMR.hx
@@ -1,5 +1,11 @@
-class ReactHMR
-{
+typedef ModuleHMR = {
+	data: Dynamic,
+	status: (String->Void)->Void,
+	accept: ?Dynamic->Void,
+	dispose: (Dynamic->Void)->Void
+}
+
+class ReactHMR {
 	/**
 	 * Deep refresh the provided React component when a module is reloaded.
      * This function should be only called once.
@@ -12,12 +18,7 @@ class ReactHMR
      *     #end
 	 */
 	static public function autoRefresh(component:Dynamic, autoReloadMain:Bool = true) {
-		var hot:{
-			data: Dynamic,
-			status: (String->Void)->Void,
-			accept: Void->Void,
-			dispose: (Dynamic->Void)->Void
-		} = untyped module.hot;
+		var hot:ModuleHMR = untyped module.hot;
 
         if (hot != null) {
 			// if main module has changed, reload the page

--- a/haxelib/ReactHMR.hx
+++ b/haxelib/ReactHMR.hx
@@ -8,19 +8,19 @@ typedef ModuleHMR = {
 class ReactHMR {
 	/**
 	 * Deep refresh the provided React component when a module is reloaded.
-     * This function should be only called once.
-     *
-     * Usage:
-     *
-     *     var rootComponent = ReactDOM.render(...);
-     *     #if debug
-     *     ReactHMR.autoRefresh(rootComponent);
-     *     #end
+	 * This function should be only called once.
+	 *
+	 * Usage:
+	 *
+	 *     var rootComponent = ReactDOM.render(...);
+	 *     #if debug
+	 *     ReactHMR.autoRefresh(rootComponent);
+	 *     #end
 	 */
 	static public function autoRefresh(component:Dynamic, autoReloadMain:Bool = true) {
 		var hot:ModuleHMR = untyped module.hot;
 
-        if (hot != null) {
+		if (hot != null) {
 			// if main module has changed, reload the page
 			if (autoReloadMain) {
 				if (hot.data != null && hot.data.forceReload) {
@@ -33,17 +33,17 @@ class ReactHMR {
 			}
 			hot.accept();
 			// if a sub-module has changed, force deep React re-render
-            var dirty = false;
-            hot.status(function(status) {
-                if (status == 'apply') dirty = true;
-                else if (status == 'idle' && dirty) {
-                    dirty = false;
-                    if (component._reactInternalInstance) {
-                        HMRClient.refresh(component);
-                    }
-                }
-            });
-        }
+			var dirty = false;
+			hot.status(function(status) {
+				if (status == 'apply') dirty = true;
+				else if (status == 'idle' && dirty) {
+					dirty = false;
+					if (component._reactInternalInstance) {
+						HMRClient.refresh(component);
+					}
+				}
+			});
+		}
 	}
 }
 
@@ -54,5 +54,5 @@ class ReactHMR {
  */
 @:jsRequire('haxe-modular')
 extern class HMRClient {
-    static public function refresh(component:Dynamic):Void;
+	static public function refresh(component:Dynamic):Void;
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "haxe-loader",
   "description": "Webpack loader for the Haxe programming language.",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "author": "Jason O'Neil <jason.oneil@gmail.com>",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
ReactHMR:
- originally, main module updates were ignored, 
- now page is reloaded,
- but it can be accepted and Main entry point is re-executed (up to you to handle it gracefully)

Webpack:
- Minor refactoring of Webpack class to expose the split point creation logic to custom macros.