### PR TITLE
Fix Webpack.require() when file is outside cwd

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ install:
   - node -v
   - npm i -g npm@5.7.1
   - npm ci
+  - haxelib install hx3compat
 
 # Keep the npm cache around to speed up installs
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,16 @@ matrix:
   allow_failures:
     - haxe: development
 
+# npm update to be able to optimize installations with `npm ci` and npm cache
 install:
-  - node -v && npm install
+  - node -v
+  - npm i -g npm@5.7.1
+  - npm ci
+
+# Keep the npm cache around to speed up installs
+cache:
+  directories:
+  - "$HOME/.npm"
 
 script:
   - npm run test

--- a/haxelib/Webpack.hx
+++ b/haxelib/Webpack.hx
@@ -120,11 +120,11 @@ class Webpack {
 	static function rebaseRelativePath(directory:String, file:String) {
 		if (file.startsWith('./')) {
 			file = file.substr(2);
-			return './${directory}/${file}';
+			return '${directory}/${file}';
 		}
 
 		while (file.startsWith('../')) {
-			if (directory.indexOf('/') > 0) {
+			if (directory.lastIndexOf('/') > 0) {
 				file = file.substr(3);
 				directory = directory.directory();
 			} else if (directory != '') {
@@ -135,7 +135,7 @@ class Webpack {
 		}
 
 		if (directory != '') {
-			return './${directory}/${file}';
+			return '${directory}/${file}';
 		}
 		if (file.startsWith('.')) {
 			// file goes further up the project root
@@ -151,9 +151,10 @@ class Webpack {
 		) {
 			var cwd = Sys.getCwd().replace('\\', '/');
 			directory = directory.replace('\\', '/');
-			if (directory.startsWith(cwd)) return directory.substr(cwd.length);
+			if (directory.startsWith(cwd)) return './${directory.substr(cwd.length)}';
+			return directory;
 		}
-		return directory;
+		return './$directory';
 	}
 	#end
 }

--- a/index.js
+++ b/index.js
@@ -221,10 +221,17 @@ function prepare(options, context, ns, hxmlContent, jsTempFile) {
         const name = hxmlOptions[i];
 
         if (name === '--next') {
-            var err = `${
-                context.resourcePath
-            } included a "--next" line, hxml-loader only supports a single build per hxml file.`;
-            throw new Error(err);
+            throw new Error(
+                `${context.resourcePath} (or \`options.extra\`) included a "--next" line, `
+                + `hxml-loader only supports a single build per hxml file.`
+            );
+        }
+
+        if (name === '-cmd') {
+            throw new Error(
+                `${context.resourcePath} (or \`options.extra\`) included a "-cmd" line, `
+                + `which is not allowed by hxml-loader.`
+            );
         }
 
         if (name === '-js' && !preventJsOutput) {
@@ -269,7 +276,7 @@ function prepare(options, context, ns, hxmlContent, jsTempFile) {
         }
 
         // Quote arguments that may need it
-        if (name === '--macro' || name === '-resource' || name === "--cwd" || name === "-cmd") {
+        if (name === '--macro' || name === '-resource' || name === "--cwd") {
             const value = hxmlOptions[++i];
             args.push(name, `"${value}"`);
             continue;

--- a/index.js
+++ b/index.js
@@ -227,9 +227,9 @@ function prepare(options, context, ns, hxmlContent, jsTempFile) {
             );
         }
 
-        if (name === '-cmd') {
+        if (name === '-cmd' || name === '--cwd') {
             throw new Error(
-                `${context.resourcePath} (or \`options.extra\`) included a "-cmd" line, `
+                `${context.resourcePath} (or \`options.extra\`) included a "${name}" line, `
                 + `which is not allowed by haxe-loader.`
             );
         }
@@ -276,7 +276,7 @@ function prepare(options, context, ns, hxmlContent, jsTempFile) {
         }
 
         // Quote arguments that may need it
-        if (name === '--macro' || name === '-resource' || name === "--cwd") {
+        if (name === '--macro' || name === '-resource') {
             const value = hxmlOptions[++i];
             args.push(name, `"${value}"`);
             continue;

--- a/index.js
+++ b/index.js
@@ -202,7 +202,7 @@ function prepare(options, context, ns, hxmlContent, jsTempFile) {
     let mainClass = 'Main';
     let preventJsOutput = false;
 
-    // Add args that are specific to hxml-loader
+    // Add args that are specific to haxe-loader
     if (options.debug) {
         args.push('-debug');
     }
@@ -223,14 +223,14 @@ function prepare(options, context, ns, hxmlContent, jsTempFile) {
         if (name === '--next') {
             throw new Error(
                 `${context.resourcePath} (or \`options.extra\`) included a "--next" line, `
-                + `hxml-loader only supports a single build per hxml file.`
+                + `haxe-loader only supports a single build per hxml file.`
             );
         }
 
         if (name === '-cmd') {
             throw new Error(
                 `${context.resourcePath} (or \`options.extra\`) included a "-cmd" line, `
-                + `which is not allowed by hxml-loader.`
+                + `which is not allowed by haxe-loader.`
             );
         }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,11 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
       "integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ=="
     },
+    "camelcase": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+    },
     "concat-stream": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
@@ -187,6 +192,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "yargs-parser": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.0.0.tgz",
+      "integrity": "sha512-+DHejWujTVYeMHLff8U96rLc4uE4Emncoftvn5AjhB1Jw1pWxLzgBUT/WYbPrHmy6YPEBTZQx5myHhVcuuu64g==",
+      "requires": {
+        "camelcase": "^4.1.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "haxe-modular": "^0.10.13",
     "loader-utils": "^1.1.0",
     "null-loader": "^0.1.1",
-    "tmp": "0.0.33"
+    "tmp": "0.0.33",
+    "yargs-parser": "^10.0.0"
   }
 }

--- a/test/src/HaxeTests.hx
+++ b/test/src/HaxeTests.hx
@@ -21,23 +21,23 @@ class WebpackTestCase extends TestCase {
     }
 
     function test_rebaseRelativePath() {
-        assert(rebaseRelativePath('src', './res') == './src/res');
-        assert(rebaseRelativePath('src/a', './res') == './src/a/res');
-        assert(rebaseRelativePath('src/a/b', './res') == './src/a/b/res');
-        assert(rebaseRelativePath('src/a/b', '../res') == './src/a/res');
-        assert(rebaseRelativePath('src/a/b', '../../res') == './src/res');
+        assert(rebaseRelativePath('src', './res') == 'src/res');
+        assert(rebaseRelativePath('src/a', './res') == 'src/a/res');
+        assert(rebaseRelativePath('src/a/b', './res') == 'src/a/b/res');
+        assert(rebaseRelativePath('src/a/b', '../res') == 'src/a/res');
+        assert(rebaseRelativePath('src/a/b', '../../res') == 'src/res');
         assert(rebaseRelativePath('src/a/b', '../../../res') == './res');
-        assert(rebaseRelativePath('src', './c/res') == './src/c/res');
+        assert(rebaseRelativePath('src', './c/res') == 'src/c/res');
         assert(rebaseRelativePath('src', '../res') == './res');
         assert(rebaseRelativePath('src', '../../res') == '../res');
         assert(rebaseRelativePath('src', '../../../res') == '../../res');
     }
 
     function test_relativePath() {
-        assert(relativePath('src/a.hx') == 'src/a.hx');
+        assert(relativePath('src/a.hx') == './src/a.hx');
         assert(relativePath('/temp/src/a.hx') == '/temp/src/a.hx');
         assert(relativePath('C:\\temp\\src\\a.hx') == 'C:/temp/src/a.hx');
-        assert(relativePath_madeAbsolute('src/a.hx') == 'src/a.hx');
+        assert(relativePath_madeAbsolute('src/a.hx') == './src/a.hx');
     }
 
     // macro functions wrappers

--- a/test/src/HaxeTests.hx
+++ b/test/src/HaxeTests.hx
@@ -20,24 +20,33 @@ class WebpackTestCase extends TestCase {
         assert(resolveModule('module') == '!haxe-loader?test/module!');
     }
 
-    function test_rebaseRelativePath() {
-        assert(rebaseRelativePath('src', './res') == 'src/res');
-        assert(rebaseRelativePath('src/a', './res') == 'src/a/res');
-        assert(rebaseRelativePath('src/a/b', './res') == 'src/a/b/res');
-        assert(rebaseRelativePath('src/a/b', '../res') == 'src/a/res');
-        assert(rebaseRelativePath('src/a/b', '../../res') == 'src/res');
-        assert(rebaseRelativePath('src/a/b', '../../../res') == './res');
-        assert(rebaseRelativePath('src', './c/res') == 'src/c/res');
-        assert(rebaseRelativePath('src', '../res') == './res');
-        assert(rebaseRelativePath('src', '../../res') == '../res');
-        assert(rebaseRelativePath('src', '../../../res') == '../../res');
+    function test_relativePath() {
+        assert(makeRelativeToCwd('src') == './src');
+        assert(makeRelativeToCwd('src/') == './src');
+        assert(makeRelativeToCwd('src/a.hx') == './src/a.hx');
+        assert(makeRelativeToCwd('/temp/src/a.hx') == '/temp/src/a.hx');
+        assert(makeRelativeToCwd('C:\\temp\\src\\a.hx') == 'C:/temp/src/a.hx');
+        assert(makeRelativeToCwd_madeAbsolute('src/a.hx') == './src/a.hx');
     }
 
-    function test_relativePath() {
-        assert(relativePath('src/a.hx') == './src/a.hx');
-        assert(relativePath('/temp/src/a.hx') == '/temp/src/a.hx');
-        assert(relativePath('C:\\temp\\src\\a.hx') == 'C:/temp/src/a.hx');
-        assert(relativePath_madeAbsolute('src/a.hx') == './src/a.hx');
+    function test_rebaseRelativePath() {
+        assert(rebaseRelativePath('./src', './res') == './src/res');
+        assert(rebaseRelativePath('./src/', './res') == './src/res');
+        assert(rebaseRelativePath('./src/a', './res') == './src/a/res');
+        assert(rebaseRelativePath('./src/a/b', './res') == './src/a/b/res');
+        assert(rebaseRelativePath('./src/a/b', '../res') == './src/a/res');
+        assert(rebaseRelativePath('./src/a/b', '../../res') == './src/res');
+        assert(rebaseRelativePath('./src/a/b', '../../../res') == './res');
+        assert(rebaseRelativePath('./src', './c/res') == './src/c/res');
+        assert(rebaseRelativePath('./src', '../res') == './res');
+        assert(rebaseRelativePath('./src', '../../res') == '../res');
+        assert(rebaseRelativePath('./src', '../../../res') == '../../res');
+        assert(rebaseRelativePath('src', '../../../res') == '../../res');
+        assert(rebaseRelativePath('/temp/src/a', '../../../res') == '/res');
+        assert(rebaseRelativePath('C:/temp/src/', '../../res') == 'C:/res');
+        assert(rebaseRelativePath('C:/src/', './res') == 'C:/src/res');
+        assert(rebaseRelativePath('C:/src/', '../res') == 'C:/res');
+        assert(rebaseRelativePath('C:/', './res') == 'C:/res');
     }
 
     // macro functions wrappers
@@ -56,26 +65,36 @@ class WebpackTestCase extends TestCase {
         return macro $v{Webpack.rebaseRelativePath(directory, file)};
     }
 
-	@:access(Webpack.relativePath)
-    macro static function relativePath(file:String) {
-        return macro $v{Webpack.relativePath(file)};
+	@:access(Webpack.makeRelativeToCwd)
+    macro static function makeRelativeToCwd(file:String) {
+        return macro $v{Webpack.makeRelativeToCwd(file)};
     }
 
-	@:access(Webpack.relativePath)
-    macro static function relativePath_madeAbsolute(frag:String) {
+	@:access(Webpack.makeRelativeToCwd)
+    macro static function makeRelativeToCwd_madeAbsolute(frag:String) {
         var file = Sys.getCwd() + frag;
-        return macro $v{Webpack.relativePath(file)};
+        return macro $v{Webpack.makeRelativeToCwd(file)};
     }
 
     // custom assert macro
 
     macro static function assert(e:haxe.macro.Expr) {
         var s = haxe.macro.ExprTools.toString(e);
+        var errMsg = switch (e.expr) {
+            case EBinop(OpEq, e1, e2):
+                macro 'assertion failed\n'
+                    + '>>>  ' + $v{s} + '\n'
+                    + '>>>  ' + ${e1} + ' != ' + ${e2};
+
+            default:
+                macro 'assertion failed\n>>>  ' + $v{s};
+        };
+
         return macro @:pos(e.pos) (function(?c:haxe.PosInfos) {
             currentTest.done = true;
             if (!$e) {
                 currentTest.success = false;
-                currentTest.error = 'assertion failed\n>>>  ' + $v{s};
+                currentTest.error = ${errMsg};
                 currentTest.posInfos = c;
                 throw currentTest;
             }

--- a/test/test-haxe.hxml
+++ b/test/test-haxe.hxml
@@ -2,6 +2,7 @@
 
 -cp ../haxelib
 -cp src
+-lib hx3compat
 -js dist/testHaxe.js
 -main HaxeTests
 -D webpack_namespace=test


### PR DESCRIPTION
I am using a strange environment where the main sources are outside the `cwd`.

When requiring with `Webpack.require()`, I end up with paths like `.//my/absolute/path/to/src/file.scss` which don't work.

I tested this version with all my projects, it worked fine. I don't know about windows nor how far the test suite goes in testing this kind of things, though.

Now including changes from #36 too:

> Now parsing both hxml and `options.extra` with `yargs-parser`'s `tokenize` function, that sanitizes command-line arguments.
>
> It is also now properly handling `--macro` (and other arguments) quotes, which is not the case atm (doubles the quotes if we have quotes in our hxml already, which solved #28 but broke the opposite case).