### PR TITLE
[Prototype] Watch all sources path

### DIFF
--- a/haxelib/CliTools.hx
+++ b/haxelib/CliTools.hx
@@ -1,0 +1,17 @@
+import haxe.macro.Context;
+import sys.FileSystem;
+
+class CliTools {
+    static function getClasspath():Void {
+		var cp = Context.getClassPath();
+
+        for (c in cp) {
+            if (c == '') continue;
+            c = FileSystem.absolutePath(c);
+            Sys.println('path: $c');
+        }
+
+        // Abort compilation
+        Sys.exit(0);
+    }
+}

--- a/index.js
+++ b/index.js
@@ -293,8 +293,10 @@ function prepare(options, context, ns, hxmlContent, jsTempFile) {
 }
 
 function getClasspath(args, fallback) {
+    const filteredArgs = args.filter(a => !a.startsWith('--connect'));
+
     return new Promise((resolve) => {
-        exec(`haxe --macro "CliTools.getClasspath()" ${args.join(' ')}`, (err, stdout, stderr) => {
+        exec(`haxe --macro "CliTools.getClasspath()" ${filteredArgs.join(' ')}`, (err, stdout, stderr) => {
             if (err) resolve(fallback);
 
             const classpath = stdout.split("\n")


### PR DESCRIPTION
Currently haxe-loader is only watching source path set by `-cp` in hxml / extra args.

This prototype is using haxe's `Context.getClassPath()` to get all source directories used by this haxe compilation, so that modifying your libs or even haxe std will trigger webpack compilation.

I'm not even sure it is something we want here. Seemed nice when I started toying around :D