### PR TITLE
Add webpack errors/warnings from haxe output

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,9 @@ The Haxe Loader supports a number of options:
 - `sizeReport`: *(Boolean)* Generate size report (see below)
 - `extra`: *(String)* Additional Haxe compiler arguments, applied after the HXML file
 - `delayForNonJsBuilds`: See [advanced usage tip with non-JS targets](webpack-tips.md)
+- `logCommand`: *(Boolean)* Logs final Haxe compiler arguments (via `console.log`)
+- `ignoreWarnings`: *(Boolean)* Do not forward Haxe warnings to webpack
+- `emitStdoutAsWarning`: *(Boolean)* Generate a webpack warning with Haxe's stdout
 
 
 ## Detailed size reporting

--- a/errorFormatter.js
+++ b/errorFormatter.js
@@ -80,8 +80,12 @@ function displaySource(
     linesAround = LINES_AROUND,
     linesInside = LINES_INSIDE
 ) {
+    if (src == null) return chalk.red('Cannot get source code for this error');
     const lines = src.split('\n');
-    if (line > lines.length) throw('Invalid error...');
+
+    if (line > lines.length) {
+        return chalk.red('Invalid error: cannot find line #' + line);
+    }
 
     const ret = [];
     line = line | 0;
@@ -114,11 +118,13 @@ function displaySource(
         let lineStr = color(isHighlighted ? '> ' : '  ');
         lineStr += color(lpad(i, String(end).length) + ' | ');
 
-        if (isHighlighted && line == endLine && (column || column === 0)) {
+        if (isHighlighted && line == endLine && column >= 0) {
             lineStr += chalk.grey(sourceLine.substring(0, column - 1));
             lineStr += chalk.white(sourceLine.substring(column - 1, endColumn - 1));
-            if (sourceLine.length >= endColumn)
+
+            if (sourceLine.length >= endColumn) {
                 lineStr += chalk.grey(sourceLine.substring(endColumn - 1));
+            }
         } else {
             lineStr += color(sourceLine);
         }

--- a/errorFormatter.js
+++ b/errorFormatter.js
@@ -1,0 +1,197 @@
+'use strict';
+
+const fs = require('fs');
+const chalk = require('chalk');
+
+const concat = require('./utils').concat;
+const formatTitle = require('./utils/colors').formatTitle;
+
+const MAX_LINES = 12;
+const LINES_AROUND = 2;
+const LINES_INSIDE = 4;
+
+function formatError(error) {
+    const severity = 'error';
+    const baseError = formatTitle(severity, severity);
+    const file = removeLoaders(error.file);
+    const src = fs.readFileSync(file, {encoding: 'utf-8'});
+
+    return concat(
+        `${baseError} in ${file}`,
+        '',
+        error.message,
+        '',
+        displaySource(src, error.positions),
+        ''
+    ).join('\n');
+}
+
+function formatWarning(warning) {
+    const severity = 'warning';
+    const baseError = formatTitle(severity, severity);
+    const file = removeLoaders(warning.file);
+    const src = fs.readFileSync(file, {encoding: 'utf-8'});
+
+    return concat(
+        `${baseError} in ${file}`,
+        '',
+        warning.message,
+        '',
+        displaySource(src, warning.positions, 5, 0, 2),
+        ''
+    ).join('\n');
+}
+
+function formatCompilationError(error) {
+    const severity = 'error';
+    const baseError = formatTitle(severity, severity);
+
+    return concat(
+        `${baseError} Compilation failed for ${removeLoaders(error.file)}`,
+        '',
+        chalk.grey(error.infos),
+        ''
+    ).join('\n');
+}
+
+function formatCompilationOutput(error) {
+    const severity = 'info';
+    const baseError = formatTitle(severity, severity);
+
+    return concat(
+        `${baseError} Compilation output for ${removeLoaders(error.file)}`,
+        '',
+        error.message
+    ).join('\n');
+}
+
+function removeLoaders(file) {
+    if (!file) return '';
+
+    const split = file.split('!');
+    const filePath = split[split.length - 1];
+    return `${filePath}`;
+}
+
+function displaySource(
+    src,
+    [line, endLine, column, endColumn],
+    maxLines = MAX_LINES,
+    linesAround = LINES_AROUND,
+    linesInside = LINES_INSIDE
+) {
+    const lines = src.split('\n');
+    if (line > lines.length) throw('Invalid error...');
+
+    const ret = [];
+    line = line | 0;
+    endLine = (endLine || line) | 0;
+    const nbLines = endLine - line + 1;
+
+    let start = line - linesAround;
+    if (start < 1) start = 1;
+
+    let end = endLine + linesAround;
+    if (end >= lines.length) end = lines.length - 1;
+        if (!endColumn && endColumn !== 0) endColumn = column;
+
+    for (let i = start; i <= end; i++) {
+        const sourceLine = lines[i - 1];
+        if (i == start && i != line && sourceLine.trim() == '') continue;
+
+        const isHighlighted = (i >= line && i <= endLine);
+        const color = isHighlighted ? chalk.white : chalk.grey;
+
+        if (isHighlighted && nbLines > maxLines) {
+            if (i - line == linesInside) {
+                ret.push(chalk.grey(' [...]'));
+                continue;
+            } else if (i - line > linesInside && endLine - i >= linesInside) {
+                continue;
+            }
+        }
+
+        let lineStr = color(isHighlighted ? '> ' : '  ');
+        lineStr += color(lpad(i, String(end).length) + ' | ');
+
+        if (isHighlighted && line == endLine && (column || column === 0)) {
+            lineStr += chalk.grey(sourceLine.substring(0, column - 1));
+            lineStr += chalk.white(sourceLine.substring(column - 1, endColumn - 1));
+            if (sourceLine.length >= endColumn)
+                lineStr += chalk.grey(sourceLine.substring(endColumn - 1));
+        } else {
+            lineStr += color(sourceLine);
+        }
+
+        ret.push(lineStr);
+    }
+
+    return ret.join('\n');
+}
+
+function lpad(str, len, ch) {
+    str = String(str);
+    let i = -1;
+    if (!ch && ch !== 0) ch = ' ';
+    len = len - str.length;
+    while (++i < len) str = ch + str;
+    return str;
+}
+
+function format(errors, type) {
+    let stdout;
+    let formattedErrors = [];
+
+    errors.sort((e1, e2) => {
+        const i1 = (e1.webpackError.error && e1.webpackError.error.index) || -1;
+        const i2 = (e2.webpackError.error && e2.webpackError.error.index) || -1;
+
+        if (i1 == -1 && i2 == -1) return 0;
+        return i1 - i2;
+    });
+
+    errors = groupErrors(errors);
+
+    errors.forEach(error => {
+        switch (error.type) {
+            case 'Haxe Error':
+                formattedErrors.push(formatError(error));
+                break;
+
+            case 'Haxe Warning':
+                formattedErrors.push(formatWarning(error));
+                break;
+
+            case 'Haxe Compilation Output':
+                stdout = formatCompilationOutput(error);
+                break;
+
+            case 'Haxe Compilation Error':
+                formattedErrors.push(formatCompilationError(error));
+                break;
+        }
+    });
+
+    if (stdout) formattedErrors = formattedErrors.concat(['', stdout]);
+    return formattedErrors;
+}
+
+function groupErrors(errors) {
+    const map = {};
+    const other = [];
+
+    errors.forEach(error => {
+        if (error.type != 'Haxe Error') return other.push(error);
+
+        const key = error.file + ':' + error.positions.join(':');
+
+        if (map[key]) map[key].message += '\n' + error.message;
+        else map[key] = error;
+    });
+
+    const groupedErrors = [];
+    for (let k in map) if (map.hasOwnProperty(k)) groupedErrors.push(map[k]);
+    return groupedErrors.concat(other);
+}
+
+module.exports = format;

--- a/errorTransformer.js
+++ b/errorTransformer.js
@@ -1,0 +1,56 @@
+'use strict';
+
+// 1: file, 2: line, 3: endline, 4: column, 5: endColumn, 6: severity, 7: message
+const problemMatcher = new RegExp(
+    "^(.+):(\\d+): (?:lines \\d+-(\\d+)|character(?:s (\\d+)-| )(\\d+)) : (?:(Warning) : )?(.*)$"
+);
+
+function isHaxeError(error) {
+    return problemMatcher.test(error.message);
+}
+
+function isHaxeCompilationError(error) {
+    return error.message.indexOf('Haxe Loader: compilation failed') > -1;
+}
+
+function isHaxeCompilationOutput(error) {
+    return error.message.indexOf('[HAXE STDOUT]\n') === 0;
+}
+
+function transform(error) {
+    if (isHaxeError(error)) {
+        const res = problemMatcher.exec(error.message);
+
+        return Object.assign({}, error, {
+            file: res[1],
+            message: res[7],
+            positions: res.slice(2, 6),
+            origin: '\n @ ' + error.file,
+            type: 'Haxe ' + (res[6] || 'Error')
+        });
+    }
+
+    if (isHaxeCompilationError(error)) {
+        const lines = error.message.split('\n');
+
+        return Object.assign({}, error, {
+            type: 'Haxe Compilation Error',
+            message: lines[0],
+            infos: lines[1]
+        });
+    }
+
+    if (isHaxeCompilationOutput(error)) {
+        const lines = error.message.split('\n');
+        lines.shift();
+
+        return Object.assign({}, error, {
+            type: 'Haxe Compilation Output',
+            message: lines.join('\n')
+        });
+    }
+
+    return error;
+}
+
+module.exports = transform;

--- a/index.js
+++ b/index.js
@@ -47,6 +47,17 @@ module.exports = function(hxmlContent) {
             return cb(err);
         }
 
+        if (stderr && options.emitWarnings) {
+            const lines = stderr.split('\n');
+            const warnReg = new RegExp("^(.+):(\\d+): (?:lines \\d+-(\\d+)|character(?:s (\\d+)-| )(\\d+)) : Warning : (.*)$");
+
+            lines.forEach(line => {
+                if (!line) return;
+                const err = new Error(line);
+                if (warnReg.test(line)) context.emitWarning(err);
+            });
+        }
+
         // If the hxml file outputs something other than client JS, we should not include it in the bundle.
         // We're only passing it through webpack so that we get `watch` and the like to work.
         if (!jsOutputFile) {

--- a/index.js
+++ b/index.js
@@ -41,21 +41,40 @@ module.exports = function(hxmlContent) {
     registerDepencencies(context, classpath);
 
     // Execute the Haxe build.
-    console.log('haxe', args.join(' '));
-    exec(`haxe ${args.join(' ')}`, (err, stdout, stderr) => {
-        if (err) {
-            return cb(err);
-        }
-
-        if (stderr && options.emitWarnings) {
+    const haxeCommand = `haxe ${args.join(' ')}`;
+    if (options.logCommand) console.log(haxeCommand);
+    exec(haxeCommand, (err, stdout, stderr) => {
+        // Parse errors and warnings
+        if (stderr) {
+            let errorIndex = 0;
             const lines = stderr.split('\n');
-            const warnReg = new RegExp("^(.+):(\\d+): (?:lines \\d+-(\\d+)|character(?:s (\\d+)-| )(\\d+)) : Warning : (.*)$");
+            const problemMatcher = new RegExp(
+                "^(.+):(\\d+): (?:lines \\d+-(\\d+)|character(?:s (\\d+)-| )(\\d+)) : (?:(Warning) : )?(.*)$"
+            );
 
             lines.forEach(line => {
-                if (!line) return;
+                if (!line || !problemMatcher.test(line)) return;
                 const err = new Error(line);
-                if (warnReg.test(line)) context.emitWarning(err);
+
+                if (problemMatcher.exec(line)[6] === 'Warning') {
+                    if (!options.ignoreWarnings) {
+                        Object.assign(err, {index: ++errorIndex});
+                        context.emitWarning(err);
+                    }
+                } else {
+                    Object.assign(err, {index: ++errorIndex});
+                    context.emitError(err);
+                }
             });
+        }
+
+        if (stdout && options.emitStdoutAsWarning) {
+            context.emitWarning(new Error('[HAXE STDOUT]\n' + stdout));
+        }
+
+        // Fail if haxe compilation failed
+        if (err) {
+            return cb(new Error(`Haxe Loader: compilation failed\n${haxeCommand}`));
         }
 
         // If the hxml file outputs something other than client JS, we should not include it in the bundle.

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,16 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
       "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
     },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+    },
     "big.js": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
@@ -31,6 +41,18 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
       "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "requires": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      }
     },
     "concat-stream": {
       "version": "1.6.2",
@@ -53,12 +75,25 @@
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
       "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
     },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
     "graphlib": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.5.tgz",
       "integrity": "sha512-XvtbqCcw+EM5SqQrIetIKKD+uZVNQtDPD1goIg7K73RuRZtVI5rYMdcCVSHm/AS1sCBZ7vt0p5WgXouucHQaOA==",
       "requires": {
         "lodash": "^4.11.1"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "requires": {
+        "ansi-regex": "^2.0.0"
       }
     },
     "hash-sum": {
@@ -169,6 +204,19 @@
       "requires": {
         "safe-buffer": "~5.1.0"
       }
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
     },
     "tmp": {
       "version": "0.0.33",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:haxe": "haxe test/test-haxe.hxml && node test/dist/testHaxe.js"
   },
   "dependencies": {
+    "chalk": "^1.1.3",
     "hash-sum": "^1.0.2",
     "haxe-modular": "^0.10.13",
     "loader-utils": "^1.1.0",

--- a/utils/colors.js
+++ b/utils/colors.js
@@ -1,0 +1,41 @@
+'use strict';
+
+// Copied from https://github.com/geowarin/friendly-errors-webpack-plugin
+// Should be removed if haxe formatter/transformer are merged there
+
+const chalk = require('chalk');
+
+function formatTitle(severity, message) {
+  return chalk[bgColor(severity)].black('', message, '');
+}
+
+function formatText(severity, message) {
+  return chalk[textColor(severity)](message);
+}
+
+function bgColor(severity) {
+  const color = textColor(severity);
+  return 'bg'+ capitalizeFirstLetter(color)
+}
+
+function textColor(serverity) {
+  switch (serverity.toLowerCase()) {
+    case 'success': return 'green';
+    case 'info': return 'blue';
+    case 'note': return 'white';
+    case 'warning': return 'yellow';
+    case 'error': return 'red';
+    default: return 'red';
+  }
+}
+
+function capitalizeFirstLetter(string) {
+  return string.charAt(0).toUpperCase() + string.slice(1);
+}
+
+module.exports = {
+  bgColor: bgColor,
+  textColor: textColor,
+  formatTitle: formatTitle,
+  formatText: formatText
+};

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,0 +1,34 @@
+'use strict';
+
+// Copied from https://github.com/geowarin/friendly-errors-webpack-plugin
+// Should be removed if haxe formatter/transformer are merged there
+
+/**
+ * Concat and flattens non-null values.
+ * Ex: concat(1, undefined, 2, [3, 4]) = [1, 2, 3, 4]
+ */
+function concat() {
+  const args = Array.from(arguments).filter(e => e != null);
+  const baseArray = Array.isArray(args[0]) ? args[0] : [args[0]];
+  return Array.prototype.concat.apply(baseArray, args.slice(1));
+}
+
+/**
+ * Dedupes array based on criterion returned from iteratee function.
+ * Ex: uniqueBy(
+ *     [{ id: 1 }, { id: 1 }, { id: 2 }],
+ *     val => val.id
+ * ) = [{ id: 1 }, { id: 2 }]
+ */
+function uniqueBy(arr, fun) {
+  const seen = {};
+  return arr.filter(el => {
+    const e = fun(el);
+    return !(e in seen) && (seen[e] = 1);
+  })
+}
+
+module.exports = {
+  concat: concat,
+  uniqueBy: uniqueBy
+};


### PR DESCRIPTION
### Webpack output with these changes

Webpack output has been changed: we are now emitting webpack errors/warnings from haxe output, parsing them using [vshaxe](https://github.com/vshaxe/vshaxe)'s problem matcher regex.

This change has not been applied to haxe-loader's errors (invalid arguments in `build.hxml`, etc.). I'm not sure it's needed, but that could be done later anyway.

#### Warnings
![2018-06-28-07 31-35-722282335](https://user-images.githubusercontent.com/6101998/42015443-ba783482-7aa7-11e8-8c4b-e288b4aeffcf.png)

#### Errors
![2018-06-28-07 32-02-600093937](https://user-images.githubusercontent.com/6101998/42015448-bf4b29ec-7aa7-11e8-9c35-df7049e5636e.png)

#### Std out (with `options.emitStdoutAsWarning`)
![2018-06-28-07 34-26-977946944](https://user-images.githubusercontent.com/6101998/42015457-c41909a8-7aa7-11e8-94eb-a5e917624adf.png)


### Webpack with error/warnings parsers

I added parsers for [`friendly-errors-webpack-plugin`](https://github.com/geowarin/friendly-errors-webpack-plugin).  They may work with little or no work with other parsers, but it's the only one I know atm.

Note: if you're wondering where [`friendly-errors-webpack-plugin`](https://github.com/geowarin/friendly-errors-webpack-plugin) comes from, is not just a random plugin and is used by [nextjs](https://github.com/zeit/next.js) amongst other projects. I think we can bet on it too, and maybe even add in the docs an example configuration using it.

#### Warnings
![2018-06-28-07 47-16-122775528](https://user-images.githubusercontent.com/6101998/42015470-caffa2c2-7aa7-11e8-9023-54a333fb1ce1.png)

#### Errors
![2018-06-28-07 47-31-657287771](https://user-images.githubusercontent.com/6101998/42015477-cf5eb538-7aa7-11e8-9257-63cf967151a4.png)

#### Errors (grouped)
![2018-06-28-07 48-27-975498054](https://user-images.githubusercontent.com/6101998/42015483-d37d7492-7aa7-11e8-81f6-1a5840ae5600.png)

#### Std out (with `options.emitStdoutAsWarning`)
![2018-06-28-07 42-40-124045732](https://user-images.githubusercontent.com/6101998/42015487-d93e7de0-7aa7-11e8-87a0-9440294681a0.png)


#### Configuration

You need to turn off errors first, setting `devServer.quiet: true`. There are ways to do that without webpack dev server, see [`friendly-errors-webpack-plugin`'s README.md](https://github.com/geowarin/friendly-errors-webpack-plugin).

Then, the plugin configuration:

```javascript
const FriendlyErrorsWebpackPlugin = require('friendly-errors-webpack-plugin');
const haxeFormatter = require('haxe-loader/errorFormatter');
const haxeTransformer = require('haxe-loader/errorTransformer');

// ...

  plugins: [
    // ...
    new FriendlyErrorsWebpackPlugin({
      compilationSuccessInfo: {
        messages: [
          `Your application is running here: https://localhost:${PORT}`
        ]
      },
      additionalTransformers: [haxeTransformer],
      additionalFormatters: [haxeFormatter]
    })
    // ...
  ]

// ...
```

### New options

##### `logCommand` *(Boolean)*

There was a `console.log` before calling haxe, to log haxe arguments. I hid it behind the `logCommand` option.

Haxe arguments are always displayed in the compilation error, and I'm not sure there is many cases where the build succeeds and we need the haxe command.

##### `ignoreWarnings` *(Boolean)*

I made this option opt-out in the end, I think warnings should be emitted / displayed by default.

##### `emitStdoutAsWarning` *(Boolean)*

Generate a webpack warning with Haxe's stdout. Can be useful when using `trace()` or `Sys.println()` in macros.

This output was not available before; I personnally had to have another "watch haxe" command running when developing macros.

### Screencast

I made a little screencast showcasing the new features [here](https://asciinema.org/a/SSIEQqRBsM5PyjxDL3Y8Ehipi).