### PR TITLE
Improve configuration errors

### DIFF
--- a/errorFormatter.js
+++ b/errorFormatter.js
@@ -47,7 +47,7 @@ function formatCompilationError(error) {
     const baseError = formatTitle(severity, severity);
 
     return concat(
-        `${baseError} Compilation failed for ${removeLoaders(error.file)}`,
+        `${baseError} ${removeLoaders(error.file)}: ${error.message}`,
         '',
         chalk.grey(error.infos),
         ''

--- a/errorTransformer.js
+++ b/errorTransformer.js
@@ -14,7 +14,7 @@ function isHaxeError(error) {
 function isHaxeCompilationError(error) {
     return error.name == 'ModuleBuildError'
         && error.message
-        && error.message.indexOf('Haxe Loader: compilation failed') > -1;
+        && error.message.split('\n').shift().indexOf('Haxe Loader: ') > -1;
 }
 
 function isHaxeCompilationOutput(error) {
@@ -39,10 +39,15 @@ function transform(error) {
     if (isHaxeCompilationError(error)) {
         const lines = error.message.split('\n');
 
+        const first = lines.shift();
+        let message = "Compilation failed";
+        const reg = /Haxe Loader: (.*)$/;
+        if (reg.test(first)) message = reg.exec(first)[1];
+
         return Object.assign({}, error, {
             type: 'Haxe Compilation Error',
-            message: lines[0],
-            infos: lines[1]
+            message: message,
+            infos: lines.join('\n')
         });
     }
 

--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ module.exports = function(hxmlContent) {
 
         // Fail if haxe compilation failed
         if (err) {
-            return cb(new Error(`Haxe Loader: compilation failed\n${haxeCommand}`));
+            return cb(makeError('Compilation failed', haxeCommand));
         }
 
         // If the hxml file outputs something other than client JS, we should not include it in the bundle.
@@ -210,6 +210,12 @@ function findImports(content) {
     return results;
 }
 
+function makeError(reason, message) {
+    const err = new Error(`Haxe Loader: ${reason}\n${message}`);
+    err.stack = "";
+    return err;
+}
+
 function makeJSTempFile() {
     const path = tmp.tmpNameSync({ postfix: '.js' });
     const nop = () => {};
@@ -224,6 +230,12 @@ function registerDepencencies(context, classpath) {
     // Listen for any changes in the classpath
     classpath.forEach(path => context.addContextDependency(path));
 }
+
+const unsupportedHaxeOptions = 'Unsupported Haxe options:\n'
+    + ' --next, --each    haxe-loader only supports a single build per hxml\n'
+    + ' -cmd, --cmd       to avoid side effects during compilation of bundles\n'
+    + ' --cwd, -C         TODO: why?\n'
+    + ' -lib modular      interaction with haxe-modular is handled internally\n';
 
 function prepare(options, context, ns, hxmlContent, jsTempFile) {
     let args = [];
@@ -251,16 +263,20 @@ function prepare(options, context, ns, hxmlContent, jsTempFile) {
         const name = hxmlOptions[i];
 
         if (name === '--next') {
-            throw new Error(
-                `${context.resourcePath} (or \`options.extra\`) included a "--next" line, `
-                + `haxe-loader only supports a single build per hxml file.`
+            throw makeError(
+                'Unsupported configuration',
+                'Hxml file or `options.extra` included a "--next" command, '
+                + 'but haxe-loader only supports a single build per hxml file.'
+                + '\n\n' + unsupportedHaxeOptions
             );
         }
 
         if (name === '-cmd' || name === '--cmd' || name === '-C' || name === '--cwd') {
-            throw new Error(
-                `${context.resourcePath} (or \`options.extra\`) included a "${name}" line, `
-                + `which is not allowed by haxe-loader.`
+            throw makeError(
+                'Unsupported configuration',
+                `Hxml file or \`options.extra\` included a "${name}" line, `
+                + 'which is not allowed by haxe-loader.'
+                + '\n\n' + unsupportedHaxeOptions
             );
         }
 
@@ -296,8 +312,11 @@ function prepare(options, context, ns, hxmlContent, jsTempFile) {
             const value = hxmlOptions[++i];
 
             if (/^modular(:|$)/.test(value)) {
-                throw new Error(
-                    'When using haxe-loader, you need to remove `-lib modular` from your hxml file'
+                throw makeError(
+                    'Unsupported configuration',
+                    'When using haxe-loader, you need to remove `-lib modular` from your hxml file '
+                    + 'and `options.extras`'
+                    + '\n\n' + unsupportedHaxeOptions
                 );
             }
 


### PR DESCRIPTION
Handled configuration errors in the same way as #42, and adding some informations to the errors.

Normal output:
![2018-06-30-13 06-44-435726241](https://user-images.githubusercontent.com/6101998/42125694-d3c8c368-7c7b-11e8-9edc-72454652e8a8.png)

Same output with [`friendly-errors-webpack-plugin`](https://github.com/geowarin/friendly-errors-webpack-plugin):
![2018-06-30-15 42-24-465724710](https://user-images.githubusercontent.com/6101998/42125710-3707e7a6-7c7c-11e8-8356-963617c45f5e.png)

Still need an explanation for `--cwd`.
