### PR TITLE
Handle sub errors (base field is defined here, defined in this class)

### DIFF
--- a/errorFormatter.js
+++ b/errorFormatter.js
@@ -254,7 +254,7 @@ function isSubError(error, previous) {
     if (error.message === 'Defined in this class') return true;
 
     if (previous.message === 'Could not find a suitable overload, reasons follow') {
-        return (error.message !== 'End of overload failure reasons')
+        return (error.message !== 'End of overload failure reasons');
     }
 
     if (previous.message === 'Extern constructor could not be inlined') {
@@ -311,7 +311,7 @@ function isSubError(error, previous) {
         && interfaceField.test(previous.message)
     ) return true;
 
-    const fieldHasNoExpression = /Field [^\s]+ has no expression `(possible typing order issue`)/;
+    const fieldHasNoExpression = /Field [^\s]+ has no expression \(possible typing order issue\)/;
     if (
         error.message.startsWith('While building')
         && fieldHasNoExpression.test(previous.message)

--- a/errorFormatter.js
+++ b/errorFormatter.js
@@ -257,10 +257,12 @@ function isSubError(error, previous) {
         return (error.message !== 'End of overload failure reasons')
     }
 
-    if (
-        error.message === 'Cancellation happened here'
-        && previous.message === 'Extern constructor could not be inlined'
-    ) return true;
+    if (previous.message === 'Extern constructor could not be inlined') {
+        if (error.message === 'Cancellation happened here') return true;
+        if (error.message === 'Variable is used here') return true;
+
+        return false;
+    }
 
     if (
         error.message === 'Add @:isVar here to enable it'

--- a/errorFormatter.js
+++ b/errorFormatter.js
@@ -42,7 +42,7 @@ function formatSubError(error) {
     return concat(
         indent + baseError + ' ' + error.message,
         indent + chalk.grey(file),
-        displaySource(src, error.positions, indent, 1, 0),
+        displaySource(src, error.positions, indent, 1, 0, 1),
         ''
     ).join('\n');
 }

--- a/errorFormatter.js
+++ b/errorFormatter.js
@@ -238,10 +238,33 @@ function groupErrors(errors) {
 function isSubError(error, previous) {
     if (error.message === 'Defined in this class') return true;
 
+    const fieldOverload = /Field [^\s]+ overloads parent class with different or incomplete type/;
     if (
         error.message === 'Base field is defined here'
+        && previous && fieldOverload.test(previous.message)
+    ) return true;
+
+    const interfaceField = /Field [^\s]+ has different type than in [^\s]+/;
+    if (
+        error.message === 'Interface field is defined here'
+        && previous && interfaceField.test(previous.message)
+    ) return true;
+
+    if (
+        error.message.indexOf('Accessor method is here') > 0
         && previous
-        && previous.message === 'Field render overloads parent class with different or incomplete type'
+        && previous.message.indexOf('Macro methods cannot be used as property accessor') > 0
+    ) return true;
+
+    const fieldHasNoExpression = /Field [^\s]+ has no expression `(possible typing order issue`)/;
+    if (
+        error.message.indexOf('While building') == 0
+        && previous && fieldHasNoExpression.test(previous.message)
+    ) return true;
+
+    if (
+        error.message === 'Cancellation happened here'
+        && previous && previous.message === 'Extern constructor could not be inlined'
     ) return true;
 
     return false;


### PR DESCRIPTION
Groups "Base field is defined here" and "Defined in this class" errors with their parent error. 
Edit: also groups other "multi-error" errors like overload resolution failures, unification failures for fields from interfaces, etc.

Has no effect when not using [`friendly-errors-webpack-plugin`](https://github.com/geowarin/friendly-errors-webpack-plugin).

Before:
![2018-07-01-13 41-50-504385944](https://user-images.githubusercontent.com/6101998/42134080-9ae7f118-7d34-11e8-851f-aa5fe1b59a01.png)

After:
![2018-07-01-13 47-18-560434158](https://user-images.githubusercontent.com/6101998/42134120-5aaac570-7d35-11e8-84cb-1a40d4db8216.png)

Overload resolution failure example: 
[before](https://user-images.githubusercontent.com/6101998/42134124-84845640-7d35-11e8-9d78-46ca1222087e.png) / [after](https://user-images.githubusercontent.com/6101998/42134118-51ec8a68-7d35-11e8-8bc3-d24439586bc2.png)

Note: errors were already grouped by location, so the overload resolution failure was already short but not easy to read.
