### PR TITLE
Problem matcher: handle \r

### DIFF
--- a/errorTransformer.js
+++ b/errorTransformer.js
@@ -2,7 +2,7 @@
 
 // 1: file, 2: line, 3: endline, 4: column, 5: endColumn, 6: severity, 7: message
 const problemMatcher = new RegExp(
-    "^(.+):(\\d+): (?:lines \\d+-(\\d+)|character(?:s (\\d+)-| )(\\d+)) : (?:(Warning) : )?(.*)$"
+    "^(.+):(\\d+): (?:lines \\d+-(\\d+)|character(?:s (\\d+)-| )(\\d+)) : (?:(Warning) : )?(.*)\r?$"
 );
 
 function isHaxeError(error) {

--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ module.exports = function(hxmlContent) {
             let errorIndex = 0;
             const lines = stderr.split('\n');
             const problemMatcher = new RegExp(
-                "^(.+):(\\d+): (?:lines \\d+-(\\d+)|character(?:s (\\d+)-| )(\\d+)) : (?:(Warning) : )?(.*)$"
+                "^(.+):(\\d+): (?:lines \\d+-(\\d+)|character(?:s (\\d+)-| )(\\d+)) : (?:(Warning) : )?(.*)\r?$"
             );
 
             lines.forEach(line => {


### PR DESCRIPTION
Seems weird since the problem matcher regex comes from `vshaxe`, but the error detection was not working on some windows environments because lines ended with `\r`.

Works with this small fix (was not working with git bash).