### PR TITLE
Add missing files to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
   },
   "files": [
     "index.js",
+    "errorFormatter.js",
+    "errorTransformer.js",
     "haxelib",
+    "utils",
     "README.md"
   ],
   "scripts": {


### PR DESCRIPTION
I had already added this commit, but apparently not in the merged PRs..

We need to include these files so that users can add the formatter & transformer to their webpack configuration.