### PR TITLE
Handle compilation server

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ The Haxe Loader supports a number of options:
 - `logCommand`: *(Boolean)* Logs final Haxe compiler arguments (via `console.log`)
 - `ignoreWarnings`: *(Boolean)* Do not forward Haxe warnings to webpack
 - `emitStdoutAsWarning`: *(Boolean)* Generate a webpack warning with Haxe's stdout
+- `server`: *(Number | String)* Use Haxe compilation server at `[host:]port`
 
 
 ## Detailed size reporting

--- a/errorFormatter.js
+++ b/errorFormatter.js
@@ -211,7 +211,8 @@ function groupErrors(errors) {
     let previous = null;
 
     errors.forEach(error => {
-        if (error.type != 'Haxe Error') return other.push(error);
+        if (error.type != 'Haxe Error' && error.type != 'Haxe Warning')
+            return other.push(error);
 
         const key = flattenPosition(error);
         let isSub = false;

--- a/errorFormatter.js
+++ b/errorFormatter.js
@@ -13,52 +13,81 @@ const LINES_INSIDE = 4;
 function formatError(error) {
     const severity = 'error';
     const baseError = formatTitle(severity, severity);
-    const file = removeLoaders(error.file);
-    const src = fs.readFileSync(file, {encoding: 'utf-8'});
+    let file = error.file;
+    let extras = [];
+
+    if (file == '--macro') {
+        file = 'initialization macro';
+    } else {
+        file = removeLoaders(file);
+        const src = fs.readFileSync(file, {encoding: 'utf-8'});
+        extras = [
+            displaySource(src, error.positions),
+            ''
+        ];
+    }
 
     const ret = concat(
         `${baseError} in ${file}`,
         '',
         error.message,
         '',
-        displaySource(src, error.positions),
-        ''
+        extras
     );
 
     if (error.contextErrors) {
-        error.contextErrors.forEach(error => ret.push(formatSubError(error)));
+        error.contextErrors.forEach(error => ret.push(formatSubError(error, 'error')));
     }
 
     return ret.join('\n');
 }
 
-function formatSubError(error) {
-    const baseError = formatTitle('error', '->');
+function formatWarning(warning) {
+    const severity = 'warning';
+    const baseError = formatTitle(severity, severity);
+    let file = warning.file;
+    let extras = [];
+
+    if (file == '--macro') {
+        file = 'initialization macro';
+    } else {
+        file = removeLoaders(file);
+        const src = fs.readFileSync(file, {encoding: 'utf-8'});
+        extras = [
+            displaySource(src, warning.positions, '', 5, 0, 2),
+            ''
+        ];
+    }
+
+    const ret = concat(
+        `${baseError} in ${file}`,
+        '',
+        warning.message,
+        '',
+        extras
+    );
+
+    if (warning.contextErrors) {
+        warning.contextErrors.forEach(warning => ret.push(formatSubError(warning, 'warning')));
+    }
+
+    return ret.join('\n');
+}
+
+function formatSubError(error, severity) {
+    const indent = '  ';
+    const baseError = formatTitle(severity, '->');
+
+    if (error.file == '--macro')
+        return indent + baseError + ' ' + error.message;
 
     const file = removeLoaders(error.file);
     const src = fs.readFileSync(file, {encoding: 'utf-8'});
-    const indent = '  ';
 
     return concat(
         indent + baseError + ' ' + error.message,
         indent + chalk.grey(file),
         displaySource(src, error.positions, indent, 1, 0, 1),
-        ''
-    ).join('\n');
-}
-
-function formatWarning(warning) {
-    const severity = 'warning';
-    const baseError = formatTitle(severity, severity);
-    const file = removeLoaders(warning.file);
-    const src = fs.readFileSync(file, {encoding: 'utf-8'});
-
-    return concat(
-        `${baseError} in ${file}`,
-        '',
-        warning.message,
-        '',
-        displaySource(src, warning.positions, '', 5, 0, 2),
         ''
     ).join('\n');
 }

--- a/errorParser.js
+++ b/errorParser.js
@@ -1,0 +1,21 @@
+'use strict';
+
+// 1: file, 2: line, 3: endline, 4: column, 5: endColumn, 6: severity, 7: message
+const problemMatcher = new RegExp(
+    "^(.+):(\\d+): (?:lines \\d+-(\\d+)|character(?:s (\\d+)-| )(\\d+)) : (?:(Warning) : )?(.*)\r?$"
+);
+
+const fatalErrorMatcher = new RegExp("^Fatal error: (.*)$");
+
+function identifyError(error) {
+    if (!error) return false;
+    if (problemMatcher.test(error)) return true;
+    if (fatalErrorMatcher.test(error)) return true;
+    return false;
+}
+
+module.exports = {
+    problemMatcher,
+    identifyError
+};
+

--- a/errorTransformer.js
+++ b/errorTransformer.js
@@ -1,9 +1,6 @@
 'use strict';
 
-// 1: file, 2: line, 3: endline, 4: column, 5: endColumn, 6: severity, 7: message
-const problemMatcher = new RegExp(
-    "^(.+):(\\d+): (?:lines \\d+-(\\d+)|character(?:s (\\d+)-| )(\\d+)) : (?:(Warning) : )?(.*)\r?$"
-);
+const problemMatcher = require('./errorParser').problemMatcher;
 
 function isHaxeError(error) {
     return (error.name == 'ModuleError' || error.name == 'ModuleWarning')

--- a/index.js
+++ b/index.js
@@ -244,6 +244,11 @@ function prepare(options, context, ns, hxmlContent, jsTempFile) {
     let mainClass = 'Main';
     let preventJsOutput = false;
 
+    // Add --connect if asked for compilation server
+    if (options.server) {
+        args.push(`--connect ${options.server}`);
+    }
+
     // Add args that are specific to haxe-loader
     if (options.debug) {
         args.push('-debug');

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "files": [
     "index.js",
     "errorFormatter.js",
+    "errorParser.js",
     "errorTransformer.js",
     "haxelib",
     "utils",


### PR DESCRIPTION
Added `server` option to allow `--connect` (adding it as first parameter, wouldn't work with `extra`) + handling of the error thrown when the compilation server cannot be reached.

Also fixed errors in initialization macros (with position being in `--macro` instead of a real file, the formatter was trying to load source code... and failing).

Also supported grouping errors for warnings, forgot them when implementing this for errors.