### PR TITLE
Add contextDependencies option

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ The Haxe Loader supports a number of options:
 - `ignoreWarnings`: *(Boolean)* Do not forward Haxe warnings to webpack
 - `emitStdoutAsWarning`: *(Boolean)* Generate a webpack warning with Haxe's stdout
 - `server`: *(Number | String)* Use Haxe compilation server at `[host:]port`
+- `watch`: *(String[])* List of additional path (directories or files) to watch
 
 
 ## Detailed size reporting

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ module.exports = function(hxmlContent) {
         jsTempFile
     );
 
-    registerDepencencies(context, classpath);
+    registerDependencies(context, options, classpath);
 
     // Execute the Haxe build.
     const haxeCommand = `haxe ${args.join(' ')}`;
@@ -184,7 +184,7 @@ function fromCache(context, query, cb) {
         throw new Error(`${ns}.hxml is not a known entry point`);
     }
 
-    registerDepencencies(context, cached.classpath);
+    registerDependencies(context, options, cached.classpath);
 
     if (!cached.results.length) {
         throw new Error(`${ns}.hxml did not emit any modules`);
@@ -226,9 +226,15 @@ function makeJSTempFile() {
     return { path, cleanup };
 }
 
-function registerDepencencies(context, classpath) {
+function registerDependencies(context, options, classpath) {
     // Listen for any changes in the classpath
     classpath.forEach(path => context.addContextDependency(path));
+
+    if (options.watch != null && Array.isArray(options.watch)) {
+        options.watch.forEach(
+            path => context.addContextDependency(path)
+        );
+    }
 }
 
 const unsupportedHaxeOptions = 'Unsupported Haxe options:\n'


### PR DESCRIPTION
Added new option (and a small typo fix):
> `contextDependencies`: *(String[])* List of additional path (directories or files) to watch

I use it to make webpack watch for changes in my translation files, etc.