### PR TITLE
Haxe loader 0.10.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ If you're unsure why you should be using Webpack, read
 ### Examples
 
 There is a small example Haxe+Webpack project presenting
-[vanilla DOM](https://github.com/elsassph/webpack-haxe-example)
-and [React](https://github.com/elsassph/webpack-haxe-example/tree/react) approaches.
+[vanilla DOM](https://github.com/elsassph/webpack-haxe-example/tree/vanilla)
+and [React](https://github.com/elsassph/webpack-haxe-example/) approaches.
 These examples gives you a sample functional Webpack config, a couple of classes and leverage
 Webpack features like:
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ You must have Haxe compiler installed: https://haxe.org/download
 
 ```js
 module.exports = {
-  devtool: 'cheap-module-eval-source-map',
+  mode: 'development',
+  devtool: 'source-map',
   entry: './app.hxml',
   output: {
     filename: 'bundle.js'
@@ -148,6 +149,32 @@ according to the module name (e.g. `com_Foo.js`).
 
 To revert to the original naming behaviour, you can add `-D webpack_nonamedchunks`.
 
+## Dev server
+
+Webpack comes with a hand dev server with Hot Module Replacement (HMR) capability:
+[Webpack DevServer](https://webpack.js.org/configuration/dev-server/#devserver)
+
+Configuration should be added to the `webpack.config.js`:
+```js
+module.exports = {
+  ...
+  devServer: {
+      compress: true,
+      port: 9000,
+      overlay: true,         // show build errors
+      hot: true,             // enable HMR
+      disableHostCheck: true // Chrome security
+  }
+  ...
+}
+```
+
+Add `webpack-dev-server` npm module and the dev server as the `start` task in `package.json`:
+
+```json
+  "scripts": {
+    "start": "webpack-dev-server"
+```
 
 ## DevTools / source maps
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,9 +33,9 @@
       "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
     },
     "buffer-from": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
-      "integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "camelcase": {
       "version": "4.1.0",
@@ -56,7 +56,7 @@
     },
     "concat-stream": {
       "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "resolved": "http://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "requires": {
         "buffer-from": "^1.0.0",
@@ -81,11 +81,11 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "graphlib": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.5.tgz",
-      "integrity": "sha512-XvtbqCcw+EM5SqQrIetIKKD+uZVNQtDPD1goIg7K73RuRZtVI5rYMdcCVSHm/AS1sCBZ7vt0p5WgXouucHQaOA==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.7.tgz",
+      "integrity": "sha512-TyI9jIy2J4j0qgPmOOrHTCtpPqJGN/aurBwc6ZT+bRii+di1I+Wv3obRhVrmBEXet+qkMaEX67dXrwsd3QQM6w==",
       "requires": {
-        "lodash": "^4.11.1"
+        "lodash": "^4.17.5"
       }
     },
     "has-ansi": {
@@ -110,17 +110,16 @@
       }
     },
     "haxe-modular": {
-      "version": "0.10.13",
-      "resolved": "https://registry.npmjs.org/haxe-modular/-/haxe-modular-0.10.13.tgz",
-      "integrity": "sha512-KKFlhjz9/alo12p55EP3978qvsrp215nmX7L9jLKnww2n3+X232Gj+u5WWmmB7rdp1APxf/z4pvCcPPZFD+g5g==",
+      "version": "0.10.15",
+      "resolved": "https://registry.npmjs.org/haxe-modular/-/haxe-modular-0.10.15.tgz",
+      "integrity": "sha512-R7x7G3qbWKlVsYVuj4847ykQpLSKrdKlHZrX/or1T/iqwT+pHBqUDH5Qf8f4/9/hYz4qf77FM2UNDiTtF7SRhA==",
       "requires": {
         "@elsassph/fast-source-map": "^0.3.0",
         "acorn": "^4.0.3",
         "graphlib": "^2.1.1",
         "react-deep-force-update": "^2.0.1",
         "react-proxy": "^2.0.8",
-        "source-map": "^0.5.6",
-        "uglifyjs": "^2.4.11"
+        "source-map": "^0.5.6"
       }
     },
     "inherits": {
@@ -149,9 +148,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "null-loader": {
       "version": "0.1.1",
@@ -169,9 +168,9 @@
       "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
     },
     "react-deep-force-update": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/react-deep-force-update/-/react-deep-force-update-2.1.1.tgz",
-      "integrity": "sha1-jqQmPNZFWgULN0RbPwj9g52G6Qk="
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/react-deep-force-update/-/react-deep-force-update-2.1.3.tgz",
+      "integrity": "sha512-lqD4eHKVuB65RyO/hGbEST53E2/GPbcIPcFYyeW/p4vNngtH4G7jnKGlU6u1OqrFo0uNfIvwuBOg98IbLHlNEA=="
     },
     "react-proxy": {
       "version": "2.0.8",
@@ -183,7 +182,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
         "core-util-is": "~1.0.0",
@@ -207,7 +206,7 @@
     },
     "string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
         "safe-buffer": "~5.1.0"
@@ -238,11 +237,6 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
-    },
-    "uglifyjs": {
-      "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/uglifyjs/-/uglifyjs-2.4.11.tgz",
-      "integrity": "sha1-NEDWTgRXWViVJEGOtkHGi7kNET4="
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "chalk": "^1.1.3",
     "hash-sum": "^1.0.2",
-    "haxe-modular": "^0.10.13",
+    "haxe-modular": "^0.10.15",
     "haxe-error-parser": "0.1.2",
     "loader-utils": "^1.1.0",
     "null-loader": "^0.1.1",


### PR DESCRIPTION
Updating Haxe Loader dependencies - npm haxe-loader 0.10.15, to use in conjunction with haxelib haxe-loader 0.9.0 which uses `import` instead of the legacy `System.import`

Also updated the readme a bit and example webpack project linked at the beginning